### PR TITLE
fix transparent thumb problem

### DIFF
--- a/offensive/assets/upload.inc
+++ b/offensive/assets/upload.inc
@@ -1128,6 +1128,7 @@ function upload_insert_file($postdata) {
 
 		$image = new Imagick("$tmpdir/{$postdata['tmpname']}");
 		$image->setGravity(imagick::GRAVITY_CENTER);
+		$image->flattenImages();
 		if(!$image->cropThumbnailImage(133,100)) {
 			trigger_error("ImageMagick/cropThumbnailImage failed", E_USER_ERROR);
 		}
@@ -1172,6 +1173,7 @@ function upload_insert_file($postdata) {
 					
 					$image = new Imagick($thumbname);
 					$image->setGravity(imagick::GRAVITY_CENTER);
+					$image->flattenImages();
 					if(!$image->cropThumbnailImage(100,100)) {
 						trigger_error("ImageMagick/cropThumbnailImage failed", E_USER_ERROR);
 					}


### PR DESCRIPTION
This should fix the transparent gif problems. Luckily it still matches with the bad thumbs already created.
