### PR TITLE
possible way to handle checking on add.

### DIFF
--- a/admin/isk/isk_import.php
+++ b/admin/isk/isk_import.php
@@ -100,18 +100,18 @@ function add_to_isk($images) {
 	// loop over images and add them to ISK
 	$counter = 0;
 	foreach($images as $image) {
-	  if($isk->img_exists($image['id'])) {
-	    echo "skipping " . $image['path'] . "\n";
-	    continue;
-	  } else {
-		  echo "adding " . $image['path'];
-		}
 		$counter++;
 		if(!($counter % 500)) {
 		  $isk->save();
 		}
 		if(!$isk->add($image["path"], $image['id'])) {
-		  echo " failed";
+		  if($isk->error()) {
+		    echo "failed " . $isk->error_msg();
+		  } else {
+		    echo "skipping " . $image['path'];
+		  }
+		} else {
+		  echo "adding " . $image['path'];
 		}
 		echo "\n";
 	}

--- a/offensive/assets/isk.inc
+++ b/offensive/assets/isk.inc
@@ -91,7 +91,21 @@ class Isk {
 	}
 	
 	// add image to ISK
-	public function add($image_path, $fileid) {
+	public function add($image_path, $fileid, $replace=false) {
+		
+		// check if ID exists. 
+		if($this->img_exists($fileid)) {
+			if($replace) {
+				$this->delete($fileid);
+			} else {
+				return false;
+			}
+		}
+		
+		if($this->error()) {
+			return false;
+		}
+		
 		$blob = $this->img_blob($image_path);
 		if($this->error()) {
 			return false;


### PR DESCRIPTION
One way to handle auto-check on add, necessary for ISK crashing if an ID exists. I wanted to avoid always deleting the original, and replacing it. By adding a parameter you can control that. But the code does always refuse to add if an image exists.

It returns false when an image exists, and by checking on false and the existence of $isk->error() you can distinguish between an actual error, or failure due to existing image.

Now it's possible to write an import variation that does always replace the image. Could even be an arg to the current script.
