### PR TITLE
trivial bug in animated gif code that caused thumbnails to be messed up.

### DIFF
--- a/offensive/assets/upload.inc
+++ b/offensive/assets/upload.inc
@@ -1271,7 +1271,7 @@ function upload_insert_topic() {
 }
 
 ###############################################################################
-function image_is_animated() {
+function image_is_animated($image) {
 	/*
 	 * other than actually *using* foreach, PHP doesn't have a way to expose how
 	 * many elements a Traversable object contains.


### PR DESCRIPTION
I dont know when/who introduced this function, but as of that point animated thumbs were messed up. We thought it had something to do with the way imagick flattens images, but it's actually just a bug :) 
