### PR TITLE
Check if an alternative filename was submitted and uses it for the filename

### DIFF
--- a/offensive/assets/upload.inc
+++ b/offensive/assets/upload.inc
@@ -242,7 +242,13 @@ function upload() {
 		// having the file extension helps ImageMagick do its thing.
 		$postdata['file_extension'] = getFileExtension($_FILES['image']['name']);
 		$postdata['tmpname'] = $postdata['tmpname'].$postdata['file_extension'];
-		$postdata['filename'] = $_FILES['image']['name'];
+		//Rename filename if filename field is submitted on the form. 
+		if(array_key_exists('filename', $_POST) && !empty($_POST['filename']))
+		{
+			$postdata['filename'] = $_POST['filename'];
+		} else {
+			$postdata['filename'] = $_FILES['image']['name'];
+		}				
 		if(array_key_exists('nsfw', $_POST) || strpos(strtolower($postdata['filename']), "[nsfw]") !== false)
 			$postdata['nsfw'] = $_POST['nsfw'];
 		if(array_key_exists('tmbo', $_POST) || strpos(strtolower($postdata['filename']), "[tmbo]") !== false)


### PR DESCRIPTION
This will check if the filename field in the $_POST exists and is not empty. If it
is empty, use the image name from $_FILES instead.

NOTE:  The form field "filename" has not been changed to a text field.  It is still hidden.  Once this is fully vetted and ready for public consumption, we can enable it. 
