### PR TITLE
Fix numAllowedUploads(): sum up votes

### DIFF
--- a/offensive/assets/upload.inc
+++ b/offensive/assets/upload.inc
@@ -94,11 +94,11 @@ function numAllowedUploads() {
 	while( $row = mysql_fetch_assoc( $result ) ) {
 		switch( $row['vote'] ) {
 			case "this is good":
-				$good = $row['thecount'];
+				$good += $row['thecount'];
 			break;
 
 			case "this is bad":
-				$bad = $row['thecount'];
+				$bad += $row['thecount'];
 			break;
 		}
 	}


### PR DESCRIPTION
Previously, numAllowedUploads() iterated over all uploads of the past 6 months but seemed to only use the votes on the last one.