### PR TITLE
Express the resizer warning's filesize in k

### DIFF
--- a/offensive/assets/upload.inc
+++ b/offensive/assets/upload.inc
@@ -841,8 +841,10 @@ function upload_checksize(&$postdata) {
 	global $filesize, $expectedFileSize;
 	if(!needCompression($tmpdir."/".$postdata['tmpname'])) 
 		return false;
-	
-	$message = "This image has a pretty big filesize for its dimensions. Expected file size: ${expectedFileSize}k. Your file: ${filesize}k.<br />If you want, I can resample it as an 90% quality JPG image.<br /><br />
+
+	$filesize_k = round($filesize / 1024);
+
+	$message = "This image has a pretty big filesize for its dimensions. Expected file size: ${expectedFileSize}k. Your file: ${filesize_k}k.<br />If you want, I can resample it as an 90% quality JPG image.<br /><br />
 		<form action=\"{$_SERVER['PHP_SELF']}\" method=\"POST\">
 			<input type=\"hidden\" name=\"c\" value=\"upload\">
 			<input type=\"submit\" name=\"killit\" value=\"Cancel this upload.\"/>


### PR DESCRIPTION
Got this when uploading a 632k file:

> This image has a pretty big filesize for its dimensions. Expected file size: 29k. Your file: 647382k.

Could've resolved this by removing the "k" after the filesize, but then it'd be "Expected size: (size in k), yours: (size in bytes)" and I thought that was kind of ass.