### PR TITLE
[frond end] Show signup link after 3 seconds

### DIFF
--- a/offensive/assets/logn.inc
+++ b/offensive/assets/logn.inc
@@ -7,7 +7,7 @@ require_once('offensive/assets/activationFunctions.inc');
 
 global $prompt, $login_message, $login_called;
 $prompt = true;
-$login_message = isOpenRegistration() ? "<a href=\"/offensive/registr.php\">don't have an account?</a>" : "";
+$login_message = "";
 $login_called = false;
 
 /* 

--- a/offensive/logn.php
+++ b/offensive/logn.php
@@ -2,6 +2,7 @@
 	set_include_path("..");
 	require_once('offensive/assets/header.inc');
 	require_once("offensive/assets/classes.inc");
+	require_once("offensive/classes/assets.inc");
 
 	/* the user can specify the redirect in the $_REQUEST['redirect'] variable.
 	 * the location the redirect defaults to is /offensive/?c=main
@@ -59,7 +60,12 @@
 <head>
 	<title><?= $_SERVER['HTTP_HOST'] ?> : do we know you?</title>
 	<link rel="stylesheet" type="text/css" href="/styles/sparse.css"/>
-	<? include_once("analytics.inc"); ?>
+	<?
+		include_once("analytics.inc");
+		JS::add("/offensive/js/jquery-1.7.1.min.js");
+		JS::emit();
+	?>
+
 </head>
 
 
@@ -98,6 +104,12 @@
 							</tr>
 							<? } ?>
 						</table>
+						<? if (isOpenRegistration()) { ?>
+							<p id="signup_link" style="text-align: center; opacity: 0;">
+								new here? it's your lucky day.<br />
+								<a href=\"/offensive/registr.php\">create an account.</a>
+							</p>
+						<? } ?>
 						<? if($redirect) { ?>
 							<input type="hidden" name="redirect" value="<?= $redirect ?>" />
 						<? } ?>
@@ -110,8 +122,27 @@
 			</td>
 		</tr>
 	</table>
+
+	
 	
 <? include 'includes/footer.txt' ?>
+
+<? 
+   // If the non-referred registration of the day hasn't been
+   // taken yet, fade the registration link in after 3 seconds
+   // (unless they start typing first).
+
+   if (isOpenRegistration()) { ?>
+	<script>
+		var timeoutId = setTimeout(function() {
+			$("#signup_link").animate({opacity: 1}, 'slow');
+		}, 3000);
+
+		$('html').keydown(function(e) {
+			clearTimeout(timeoutId);
+		})
+	</script>
+<? } ?>
 
 </body>
 </html>

--- a/offensive/logn.php
+++ b/offensive/logn.php
@@ -107,7 +107,7 @@
 						<? if (isOpenRegistration()) { ?>
 							<p id="signup_link" style="text-align: center; opacity: 0;">
 								new here? it's your lucky day.<br />
-								<a href=\"/offensive/registr.php\">create an account.</a>
+								<a href="/offensive/registr.php">create an account</a>
 							</p>
 						<? } ?>
 						<? if($redirect) { ?>
@@ -130,17 +130,25 @@
 <? 
    // If the non-referred registration of the day hasn't been
    // taken yet, fade the registration link in after 3 seconds
-   // (unless they start typing first).
+   // of non-activity.
 
    if (isOpenRegistration()) { ?>
 	<script>
-		var timeoutId = setTimeout(function() {
-			$("#signup_link").animate({opacity: 1}, 'slow');
-		}, 3000);
+		var timeoutId = -1;
+		resetLinkTimeout();
 
 		$('html').keydown(function(e) {
-			clearTimeout(timeoutId);
-		})
+			resetLinkTimeout();
+		});
+
+		function resetLinkTimeout() {
+			if (timeoutId != -1)
+				clearTimeout(timeoutId);
+
+			timeoutId = setTimeout(function() {
+				$("#signup_link").animate({opacity: 1}, 'slow');
+			}, 3000);
+		}
 	</script>
 <? } ?>
 


### PR DESCRIPTION
Now that we're allowing one non-referred signup every day, show a registration link on the login page after 3 seconds of non-activity. 

![image](https://cloud.githubusercontent.com/assets/189616/12219837/acf95648-b708-11e5-90a1-5f601d1f0055.png)
