### PR TITLE
Add Docker Compose development environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# TMBO Docker Environment Variables
+# Copy this file to .env and update values for your environment
+
+# MySQL Configuration
+MYSQL_ROOT_PASSWORD=change_me_in_production
+MYSQL_DATABASE=tmbo
+MYSQL_USER=tmbo
+MYSQL_PASSWORD=change_me_in_production
+
+# Application Environment
+TMBO_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@ admin/certificates
 *.swp
 todo.txt
 .vagrant/
+
+# Docker runtime/generated files
+services/temp/
+services/web/src/
+services/nginx/certs/
+services/nginx/private/
+
+# Claude Code
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
 This Might Be Offensive
 =======================
 
-Getting Started
----------------
+Getting Started (Docker)
+------------------------
+
+1. Install Docker and Docker Compose
+2. `git clone git@github.com:numist/this-might-be-offensive.git`
+3. `cd this-might-be-offensive`
+4. `./scripts/dev-setup.sh`
+5. `docker compose up`
+6. Point your browser to [`https://localhost/offensive`](https://localhost/offensive/) (accept the self-signed certificate warning)
+7. Log in as `admin`/`[nsfw]`
+
+To include cron jobs (for zip file creation, cleanup, and comment indexing):
+
+```bash
+docker compose --profile full up
+```
+
+**Services:**
+
+- **nginx** - Web server (ports 80/443)
+- **php** - PHP-FPM for application code
+- **db** - MySQL 8.0 (exposed on port 3307 for local access)
+- **redis** - Session and cache storage
+- **realtime** - Node.js WebSocket server
+- **cron** - Scheduled tasks (only with `--profile full`)
+
+Getting Started (Vagrant - Legacy)
+----------------------------------
 
 1. Install vagrant and virtualbox. If you're on a Mac: `brew install Caskroom/cask/vagrant Caskroom/cask/virtualbox`
 2. `git clone git@github.com:numist/this-might-be-offensive.git`
@@ -13,18 +39,15 @@ Getting Started
 
 The codebase is installed in the vm at `~/sites/tmbo`
 
-### Common Gotchas ###
+Common Gotchas
+--------------
 
-#### Realtime Data ####
+Realtime Data: Self-signed certs can pose a problem for realtime, but launching Chrome with `--ignore-certificate-errors` will get it working.
 
-Self-signed certs can pose a problem for realtime, but launching Chrome with `--ignore-certificate-errors` will get it working.
+Hotlinking Restrictions: tmbo's content protection is the same in development as it is in production, which means if you browse to your instance by IP, you're not going to see any images. You should either disable the relevant section in the nginx config, or add the ip address you use to the allowed hosts.
 
-#### Hotlinking Restrictions ####
-
-tmbo's content protection is the same in development as it is in production, which means if you browse to your instance by IP, you're not going to see any images. You should either disable the relevant section in the nginx config, or add the ip address you use to the allowed hosts. 
-
-Help!
------
+Help
+----
 
 Problems with the web site are frequently well-documented by error messages emitted by trigger-error. Administrators see this output as part of the rendered page, but it is also recorded to the httpd's logs. On the VM they are located in `~/logs/`.
 

--- a/admin/.config.docker
+++ b/admin/.config.docker
@@ -1,0 +1,7 @@
+[tmbo]
+database_host = "db"
+database_user = "tmbo"
+database_pass = "shortbus"
+database_name = "tmbo"
+redis_host = "redis"
+use_isk = 0

--- a/admin/database/schema.sql
+++ b/admin/database/schema.sql
@@ -244,7 +244,7 @@ CREATE TABLE `offensive_uploads` (
   `filename` varchar(255) NOT NULL DEFAULT '',
   `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `ip` varchar(16) DEFAULT NULL,
-  `nsfw` tinyint(4) NOT NULL,
+  `nsfw` tinyint(4) NOT NULL DEFAULT 0,
   `hash` varchar(32) DEFAULT NULL,
   `tmbo` tinyint(4) NOT NULL DEFAULT '0',
   `type` enum('image','topic','audio','video','avatar') NOT NULL DEFAULT 'image',

--- a/admin/mysqlConnectionInfo.inc
+++ b/admin/mysqlConnectionInfo.inc
@@ -33,7 +33,8 @@ function openDbConnection() {
 		
 		// Overloading this into the db connect since the combination is our "database"
 		if(!$redis) {
-			$redis = new Predis\Client();
+			$redis_host = isset($config['redis_host']) ? $config['redis_host'] : 'localhost';
+			$redis = new Predis\Client(['host' => $redis_host]);
 		}
 		return $link;		
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,61 @@
+# Production overrides
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+services:
+  nginx:
+    restart: always
+    volumes:
+      # In production, use named volumes instead of bind mounts
+      - app_code:/var/www/html:ro
+      - uploads:/var/www/html/offensive/uploads:rw
+      - zips:/var/www/html/offensive/zips:rw
+      - quarantine:/var/www/html/offensive/quarantine:rw
+      # Mount production SSL certificates
+      - ./services/nginx/certs/production:/etc/ssl/certs:ro
+      - ./services/nginx/private/production:/etc/ssl/private:ro
+
+  php:
+    restart: always
+    environment:
+      - TMBO_ENV=production
+    volumes:
+      - app_code:/var/www/html
+      - uploads:/var/www/html/offensive/uploads:rw
+      - zips:/var/www/html/offensive/zips:rw
+      - quarantine:/var/www/html/offensive/quarantine:rw
+      - ./admin/.config.prod:/var/www/html/admin/.config:ro
+
+  db:
+    restart: always
+    ports: []  # Don't expose database port in production
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-tmbo}
+      MYSQL_USER: ${MYSQL_USER:-tmbo}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+
+  redis:
+    restart: always
+
+  realtime:
+    restart: always
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - ./admin/.config.prod:/app/admin/.config:ro
+
+  cron:
+    restart: always
+    profiles: []  # Always run cron in production (remove profile requirement)
+    volumes:
+      - app_code:/var/www/html
+      - uploads:/var/www/html/offensive/uploads:rw
+      - zips:/var/www/html/offensive/zips:rw
+      - quarantine:/var/www/html/offensive/quarantine:rw
+      - ./admin/.config.prod:/var/www/html/admin/.config:ro
+
+volumes:
+  app_code:
+  uploads:
+  zips:
+  quarantine:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,129 @@
+services:
+  nginx:
+    build:
+      context: .
+      dockerfile: services/nginx/Dockerfile
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./:/var/www/html:ro
+      - ./services/web/src/offensive/uploads:/var/www/html/offensive/uploads:rw
+      - ./services/web/src/offensive/zips:/var/www/html/offensive/zips:rw
+      - ./services/web/src/offensive/quarantine:/var/www/html/offensive/quarantine:rw
+      - ./services/nginx/certs:/etc/ssl/certs:ro
+      - ./services/nginx/private:/etc/ssl/private:ro
+    depends_on:
+      php:
+        condition: service_healthy
+      realtime:
+        condition: service_started
+    networks:
+      - tmbo-network
+
+  php:
+    build:
+      context: .
+      dockerfile: services/php/Dockerfile
+    volumes:
+      - ./:/var/www/html
+      - ./services/web/src/offensive/uploads:/var/www/html/offensive/uploads:rw
+      - ./services/web/src/offensive/zips:/var/www/html/offensive/zips:rw
+      - ./services/web/src/offensive/quarantine:/var/www/html/offensive/quarantine:rw
+      - ./admin/.config.docker:/var/www/html/admin/.config:ro
+    environment:
+      - TMBO_ENV=development
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - tmbo-network
+    healthcheck:
+      test: ["CMD-SHELL", "php-fpm -t 2>/dev/null || exit 1"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+
+  db:
+    image: mysql:8.0
+    command: >
+      --default-authentication-plugin=mysql_native_password
+      --character-set-server=utf8
+      --collation-server=utf8_general_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: shortbus
+      MYSQL_DATABASE: tmbo
+      MYSQL_USER: tmbo
+      MYSQL_PASSWORD: shortbus
+    volumes:
+      - ./services/data/db-setup:/docker-entrypoint-initdb.d:ro
+      - mysql_data:/var/lib/mysql
+    ports:
+      - "3307:3306"
+    networks:
+      - tmbo-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pshortbus"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    networks:
+      - tmbo-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  realtime:
+    build:
+      context: .
+      dockerfile: services/realtime/Dockerfile
+    volumes:
+      - ./admin/.config.docker:/app/admin/.config:ro
+    environment:
+      - NODE_ENV=development
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - tmbo-network
+
+  cron:
+    build:
+      context: .
+      dockerfile: services/cron/Dockerfile
+    volumes:
+      - ./:/var/www/html
+      - ./services/web/src/offensive/uploads:/var/www/html/offensive/uploads:rw
+      - ./services/web/src/offensive/zips:/var/www/html/offensive/zips:rw
+      - ./services/web/src/offensive/quarantine:/var/www/html/offensive/quarantine:rw
+      - ./admin/.config.docker:/var/www/html/admin/.config:ro
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - tmbo-network
+    profiles:
+      - full
+
+volumes:
+  mysql_data:
+  redis_data:
+
+networks:
+  tmbo-network:
+    driver: bridge

--- a/offensive/assets/core.inc
+++ b/offensive/assets/core.inc
@@ -539,8 +539,9 @@
 		updateCommentCount($fileid, $good_count, $bad_count, $repost, $offensive, $comment_count);
 
 		// add the comment to the database
-		$sql = "INSERT INTO offensive_comments ( userid, fileid, comment, vote, offensive, repost, user_ip ) 
-		        VALUES ( $userid, $fileid, '$comment', '$vote', $offensive, $repost, '".sqlEscape($_SERVER['REMOTE_ADDR'])."')";
+		$vote_sql = $vote ? "'$vote'" : "NULL";
+		$sql = "INSERT INTO offensive_comments ( userid, fileid, comment, vote, offensive, repost, user_ip )
+		        VALUES ( $userid, $fileid, '$comment', $vote_sql, $offensive, $repost, '".sqlEscape($_SERVER['REMOTE_ADDR'])."')";
 		tmbo_query($sql);
 		$commentid = mysql_insert_id();
 

--- a/realtime/app.js
+++ b/realtime/app.js
@@ -2,10 +2,9 @@ var util = require("util"),
   io = require("socket.io").listen(1337),
   path = require("path"),
   iniparser = require("iniparser"),
-  mysql = require("mysql"),
-  redis = require("redis").createClient();
+  mysql = require("mysql");
 
-var db_config = iniparser.parseSync(path.normalize(path.join(__dirname, '../admin/.config'))).tmbo;
+var db_config = iniparser.parseSync(path.normalize(path.join(__dirname, 'admin/.config'))).tmbo;
 
 // iniparser returns everything as a literal, so we need to eval strings if they are literal strings
 function checkIniString(data) {
@@ -14,6 +13,10 @@ function checkIniString(data) {
   else
     return data;
 }
+
+var redis_host = checkIniString(db_config.redis_host) || 'localhost';
+// Old redis module (0.8.x) uses positional args: createClient(port, host)
+var redis = require("redis").createClient(6379, redis_host);
 
 var db = mysql.createConnection({
   user: checkIniString(db_config.database_user),

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "iniparser": "~1.0.5",
-    "mysql": "~2.0.0-alpha4",
+    "mysql": "^2.18.1",
     "redis": "~0.8.2",
     "cookies": "~0.3.6",
     "socket.io": "~0.9.11"

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "Setting up TMBO development environment..."
+
+# Create SSL certificate directories
+mkdir -p "$PROJECT_ROOT/services/nginx/certs"
+mkdir -p "$PROJECT_ROOT/services/nginx/private"
+
+# Generate self-signed SSL certificates if they don't exist
+if [ ! -f "$PROJECT_ROOT/services/nginx/certs/tmbo.pem" ]; then
+    echo "Generating self-signed SSL certificates..."
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout "$PROJECT_ROOT/services/nginx/private/tmbo.key" \
+        -out "$PROJECT_ROOT/services/nginx/certs/tmbo.pem" \
+        -subj "/C=US/ST=Dev/L=Local/O=TMBO/CN=localhost"
+    echo "SSL certificates generated."
+else
+    echo "SSL certificates already exist, skipping generation."
+fi
+
+# Create upload directories if they don't exist
+mkdir -p "$PROJECT_ROOT/services/web/src/offensive/uploads"
+mkdir -p "$PROJECT_ROOT/services/web/src/offensive/zips"
+mkdir -p "$PROJECT_ROOT/services/web/src/offensive/quarantine"
+
+echo ""
+echo "Development setup complete!"
+echo ""
+echo "To start the application, run:"
+echo "  docker compose up"
+echo ""
+echo "To start with cron jobs enabled:"
+echo "  docker compose --profile full up"
+echo ""
+echo "The application will be available at:"
+echo "  https://localhost (accept the self-signed certificate warning)"
+echo ""
+echo "Default login credentials (from populate.sql):"
+echo "  Username: admin"
+echo "  Password: [nsfw]"
+echo ""

--- a/services/cron/Dockerfile
+++ b/services/cron/Dockerfile
@@ -1,0 +1,30 @@
+FROM devilbox/php-fpm:5.6-prod
+
+# Use archived Debian repos for Stretch (EOL)
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+
+# Install cron, Perl, and dependencies
+RUN apt-get update && apt-get install -y --allow-unauthenticated \
+    cron \
+    perl \
+    libdbi-perl \
+    libarchive-zip-perl \
+    libimage-size-perl \
+    cpanminus \
+    zip \
+    && cpanm --notest ConfigReader::Simple \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy crontab
+COPY services/cron/crontab /etc/cron.d/tmbo
+RUN chmod 0644 /etc/cron.d/tmbo && crontab /etc/cron.d/tmbo
+
+# Create log file for cron output
+RUN touch /var/log/cron.log
+
+WORKDIR /var/www/html
+
+# Run cron in the foreground
+CMD ["cron", "-f"]

--- a/services/cron/crontab
+++ b/services/cron/crontab
@@ -1,0 +1,14 @@
+THEMAXX=/var/www/html
+
+# m     h       dom     mon     dow     cmd
+# Delete old zip files (older than 7 days)
+5 0 * * * www-data $THEMAXX/offensive/deleteOldFiles.pl 7 zips > /dev/null 2>&1
+
+# Create zip files from yesterday's uploads
+2 0 * * * www-data $THEMAXX/offensive/zipYesterday.pl zips > /dev/null 2>&1
+
+# Delete old quarantine files (older than 2 days)
+3 1 * * * www-data $THEMAXX/offensive/deleteOldFiles.pl 2 quarantine > /dev/null 2>&1
+
+# Run comment indexer hourly
+0 * * * * www-data /usr/bin/nice /usr/bin/php $THEMAXX/admin/commentIndexer.php > /dev/null 2>&1

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -1,0 +1,18 @@
+FROM nginx:1.24-alpine
+
+# Remove default config
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy nginx configuration
+COPY services/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY services/nginx/tmbo.conf /etc/nginx/conf.d/tmbo.conf
+
+# Create SSL directories (certs will be mounted)
+RUN mkdir -p /etc/ssl/certs /etc/ssl/private
+
+# Create log directory
+RUN mkdir -p /var/log/nginx
+
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -1,0 +1,35 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Gzip compression
+    gzip on;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/xml application/xml+rss text/javascript;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/services/nginx/tmbo.conf
+++ b/services/nginx/tmbo.conf
@@ -1,0 +1,102 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+
+    root /var/www/html;
+
+    error_log /var/log/nginx/tmbo-error.log;
+    access_log /var/log/nginx/tmbo-access.log combined;
+
+    index index.php index.html index.htm;
+    client_max_body_size 20M;
+
+    # Health check endpoint for nginx
+    location /nginx_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        allow 10.0.0.0/8;
+        deny all;
+    }
+
+    # PHP-FPM status endpoint
+    location /fpm_status {
+        access_log off;
+        include fastcgi_params;
+        fastcgi_pass php:9000;
+        allow 127.0.0.1;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        allow 10.0.0.0/8;
+        deny all;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html /index.php;
+    }
+
+    location /offensive {
+        error_page 404 /offensive/404.php;
+        error_page 403 /offensive/403.php;
+    }
+
+    # Block access to admin directory
+    location /admin {
+        return 403;
+    }
+
+    # Pass PHP scripts to PHP-FPM via TCP
+    location ~ \.php(/.+)?$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        if (!-f $document_root$fastcgi_script_name) {
+            return 404;
+        }
+
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    # Image hotlink protection (disabled for development)
+    # location ~* [^(tmbologo)]\.(jpe?g|gif|png)$ {
+    #     valid_referers none blocked *.tmbo.org tmbo.org localhost;
+    #     if ($invalid_referer) {
+    #         rewrite ^ /tmbologo.gif;
+    #     }
+    # }
+
+    # Deny access to .htaccess files
+    location ~ /\.ht {
+        deny all;
+    }
+
+    # Realtime WebSocket proxy to Node.js service
+    location /socket.io {
+        proxy_pass http://realtime:1337/socket.io;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
+
+    # SSL Configuration
+    ssl_certificate /etc/ssl/certs/tmbo.pem;
+    ssl_certificate_key /etc/ssl/private/tmbo.key;
+
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+}

--- a/services/php/Dockerfile
+++ b/services/php/Dockerfile
@@ -1,0 +1,22 @@
+FROM devilbox/php-fpm:5.6-prod
+
+# The devilbox image already includes most extensions including imagick
+# No additional apt-get needed
+
+# Copy PHP configuration - devilbox uses /usr/local/etc paths
+COPY services/php/php.ini /usr/local/etc/php/php.ini
+COPY services/php/www.conf /usr/local/etc/php-fpm.d/www.conf
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Create upload directories with proper permissions
+RUN mkdir -p /var/www/html/offensive/uploads \
+             /var/www/html/offensive/zips \
+             /var/www/html/offensive/quarantine \
+    && chown -R devilbox:devilbox /var/www/html/offensive
+
+EXPOSE 9000
+
+# Use the default entrypoint and command from devilbox image
+# The devilbox image runs php-fpm automatically via its entrypoint

--- a/services/php/php.ini
+++ b/services/php/php.ini
@@ -1,0 +1,117 @@
+[PHP]
+engine = On
+short_open_tag = On
+asp_tags = Off
+precision = 14
+output_buffering = 4096
+zlib.output_compression = Off
+implicit_flush = Off
+unserialize_callback_func =
+serialize_precision = 17
+disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,
+disable_classes =
+zend.enable_gc = On
+expose_php = On
+max_execution_time = 30
+max_input_time = 60
+memory_limit = 128M
+error_reporting = E_ALL & ~E_DEPRECATED
+display_errors = On
+display_startup_errors = On
+log_errors = On
+log_errors_max_len = 1024
+ignore_repeated_errors = Off
+ignore_repeated_source = Off
+report_memleaks = On
+track_errors = On
+html_errors = On
+variables_order = "GPCS"
+request_order = "GP"
+register_argc_argv = Off
+auto_globals_jit = On
+post_max_size = 20M
+auto_prepend_file =
+auto_append_file =
+default_mimetype = "text/html"
+doc_root =
+user_dir =
+enable_dl = Off
+file_uploads = On
+upload_max_filesize = 20M
+max_file_uploads = 20
+allow_url_fopen = On
+allow_url_include = Off
+default_socket_timeout = 60
+
+[CLI Server]
+cli_server.color = On
+
+[Date]
+date.timezone = UTC
+
+[Pdo_mysql]
+pdo_mysql.cache_size = 2000
+pdo_mysql.default_socket=
+
+[mail function]
+SMTP = localhost
+smtp_port = 25
+mail.add_x_header = On
+
+[SQL]
+sql.safe_mode = Off
+
+[MySQL]
+mysql.allow_local_infile = On
+mysql.allow_persistent = On
+mysql.cache_size = 2000
+mysql.max_persistent = -1
+mysql.max_links = -1
+mysql.default_port =
+mysql.default_socket =
+mysql.default_host =
+mysql.default_user =
+mysql.default_password =
+mysql.connect_timeout = 60
+mysql.trace_mode = Off
+
+[MySQLi]
+mysqli.max_persistent = -1
+mysqli.allow_persistent = On
+mysqli.max_links = -1
+mysqli.cache_size = 2000
+mysqli.default_port = 3306
+mysqli.default_socket =
+mysqli.default_host =
+mysqli.default_user =
+mysqli.default_pw =
+mysqli.reconnect = Off
+
+[Session]
+session.save_handler = files
+session.save_path = /tmp
+session.use_strict_mode = 0
+session.use_cookies = 1
+session.use_only_cookies = 1
+session.name = PHPSESSID
+session.auto_start = 0
+session.cookie_lifetime = 0
+session.cookie_path = /
+session.cookie_domain =
+session.cookie_httponly =
+session.serialize_handler = php
+session.gc_probability = 1
+session.gc_divisor = 1000
+session.gc_maxlifetime = 1440
+session.referer_check =
+session.cache_limiter = nocache
+session.cache_expire = 180
+session.use_trans_sid = 0
+session.hash_function = 0
+session.hash_bits_per_character = 5
+
+[opcache]
+opcache.enable = 1
+opcache.memory_consumption = 128
+opcache.max_accelerated_files = 10000
+opcache.revalidate_freq = 0

--- a/services/php/www.conf
+++ b/services/php/www.conf
@@ -1,0 +1,32 @@
+[www]
+user = www-data
+group = www-data
+
+; Listen on TCP port 9000 for Docker networking
+listen = 9000
+listen.owner = www-data
+listen.group = www-data
+
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 5
+pm.status_path = /fpm_status
+
+; Ensure proper file permissions for uploads
+chdir = /
+
+; Catch worker output
+catch_workers_output = yes
+
+; Environment variables
+env[HOSTNAME] = $HOSTNAME
+env[PATH] = /usr/local/bin:/usr/bin:/bin
+env[TMP] = /tmp
+env[TMPDIR] = /tmp
+env[TEMP] = /tmp
+
+; PHP admin values
+php_admin_value[error_log] = /proc/self/fd/2
+php_admin_flag[log_errors] = on

--- a/services/realtime/Dockerfile
+++ b/services/realtime/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:14-alpine
+
+WORKDIR /app
+
+# Copy package.json for dependency installation
+COPY realtime/package.json ./
+
+# Install dependencies with legacy peer deps for old socket.io
+RUN npm install --legacy-peer-deps
+
+# Copy the application code
+COPY realtime/ ./
+
+# Create admin directory for config file mount
+RUN mkdir -p /app/admin
+
+EXPOSE 1337
+
+ENV NODE_ENV=production
+
+CMD ["node", "app.js"]


### PR DESCRIPTION
Dockerize the application with services for nginx, PHP-FPM, MySQL 8, Redis, realtime (Node.js), and cron jobs. This provides a modern alternative to the Vagrant-based setup.

Changes:
- Add docker-compose.yml and docker-compose.prod.yml
- Add Dockerfiles and configs in services/ for each component
- Add dev-setup.sh script for SSL cert generation and directory setup
- Add .env.example for environment configuration
- Add .config.docker for Docker-specific app settings
- Update realtime/app.js to support configurable Redis host
- Update mysqlConnectionInfo.inc to support configurable Redis host
- Fix MySQL 8 strict mode compatibility issues:
  - Add DEFAULT 0 to nsfw column in offensive_uploads schema
  - Use NULL instead of empty string for vote column in comments
- Update README with Docker setup instructions

Notes:
- I'd taken a run at this previously. This version is mostly via Claude.
- search doesn't work in the container because Xapian is not installed.