### PR TITLE
Set secure and httponly on the session cookie

### DIFF
--- a/offensive/assets/header.inc
+++ b/offensive/assets/header.inc
@@ -61,6 +61,18 @@ if(!ssl()) {
  */
 session_name("TMBOSESS1");
 
+/* the session cookie never carried secure or httponly: they aren't set in
+ * php.ini and nothing set them in code, so the flags default off.  this site
+ * redirects every request to https a few lines above, and the session cookie is
+ * a login credential, so it has no business travelling in the clear or being
+ * readable from script.  set them here rather than in php.ini because changing
+ * php.ini needs root on the host, which we don't have.
+ *
+ * lifetime 0 and path / preserve the existing behaviour; only the last two
+ * arguments are a change.
+ */
+session_set_cookie_params(0, "/", "", true, true);
+
 // if we are not an admin, buffer output until the end in case of fatal errors.
 session_start();
 //ob_start("ob_gzhandler", 0);

--- a/offensive/assets/logn.inc
+++ b/offensive/assets/logn.inc
@@ -111,6 +111,7 @@ function logInUser($myself, $session=true) {
 				// must match header.inc; see the note there.  guarded because
 				// session_name() warns if a session is already active.
 				session_name("TMBOSESS1");
+				session_set_cookie_params(0, "/", "", true, true);
 				session_start();
 			}
 			$_SESSION['userid'] = $myself->id();

--- a/offensive/logout.php
+++ b/offensive/logout.php
@@ -2,6 +2,7 @@
 	// must match header.inc; see the note there.  this file includes nothing,
 	// so the name is repeated rather than shared.
 	session_name("TMBOSESS1");
+	session_set_cookie_params(0, "/", "", true, true);
 	session_start();
 	session_unset();
 	// flags must match the ones issueRememberCookie() sets in logn.inc.


### PR DESCRIPTION
The session cookie is a login credential but carries neither `Secure` nor `HttpOnly`, in any environment.

`session.cookie_secure` is commented out and `session.cookie_httponly` is empty in `php.ini`, and nothing in the codebase set them, so both default off. Confirmed identical on prod and sandbox.

## Why it's easy to miss

The `remember` cookie sits directly beside it in the inspector showing both flags — but those come from an explicit `setcookie(..., true, true)` in `issueRememberCookie()`, which covers that cookie and nothing else. The session cookie was relying on `php.ini`, and `php.ini` says nothing.

Comparing the two in devtools reads as an environment difference when it's actually a difference between two cookies.

## The change

`session_set_cookie_params(0, "/", "", true, true)` before each `session_start()`, at all three call sites, matching how `session_name()` is already handled:

- `offensive/assets/header.inc`
- `offensive/assets/logn.inc` (inside the existing `session_id() == ""` guard)
- `offensive/logout.php`

Lifetime `0` and path `/` preserve current behaviour — only the last two arguments change.

Set in code rather than `php.ini` because `session_set_cookie_params()` overrides `php.ini`, it works without root on the host, and it puts the guarantee somewhere reviewable instead of in a system file outside the checkout that nothing keeps in sync between environments.

## Testing

All three files lint clean against PHP 5.6, and the three call sites verified consistent.

Worth confirming in a browser after deploy: log in fresh and check `TMBOSESS1` shows `Secure` and `HttpOnly`. Note the site already forces https in `header.inc`, so `Secure` costs nothing — but any plain-http dev setup would stop keeping a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
