### PR TITLE
Bump the session cookie name to TMBOSESS2

### DIFF
--- a/offensive/assets/header.inc
+++ b/offensive/assets/header.inc
@@ -58,8 +58,14 @@ if(!ssl()) {
  * TMBOSESS1: sessions predating the remember-cookie fix could have been created
  * by a forged cookie, and loginWithSession() runs before loginWithCookie(), so
  * fixing the cookie did not by itself dislodge them.
+ *
+ * TMBOSESS2: secure and httponly were added to the session cookie below, but php
+ * only emits Set-Cookie when it creates a session -- resuming one from a valid
+ * cookie sends no header at all, so existing sessions would have kept their old
+ * flagless cookies until each browser happened to discard them.  renaming forces
+ * every client to be issued a fresh cookie carrying the flags.
  */
-session_name("TMBOSESS1");
+session_name("TMBOSESS2");
 
 /* the session cookie never carried secure or httponly: they aren't set in
  * php.ini and nothing set them in code, so the flags default off.  this site

--- a/offensive/assets/logn.inc
+++ b/offensive/assets/logn.inc
@@ -110,7 +110,7 @@ function logInUser($myself, $session=true) {
 			if(session_id() == "") {
 				// must match header.inc; see the note there.  guarded because
 				// session_name() warns if a session is already active.
-				session_name("TMBOSESS1");
+				session_name("TMBOSESS2");
 				session_set_cookie_params(0, "/", "", true, true);
 				session_start();
 			}

--- a/offensive/logout.php
+++ b/offensive/logout.php
@@ -1,7 +1,7 @@
 <?php
 	// must match header.inc; see the note there.  this file includes nothing,
 	// so the name is repeated rather than shared.
-	session_name("TMBOSESS1");
+	session_name("TMBOSESS2");
 	session_set_cookie_params(0, "/", "", true, true);
 	session_start();
 	session_unset();


### PR DESCRIPTION
Follow-up to #116. Adding `secure` and `httponly` only affects cookies PHP actually issues — and it doesn't issue one for a session it's merely resuming.

## The problem

Verified against PHP 5.6:

| Request | Response |
|---|---|
| no cookie presented | `Set-Cookie: TMBOSESS2=...; path=/; secure; HttpOnly` |
| valid session cookie presented | **no `Set-Cookie` header at all** |

So every session already in flight when #116 deployed kept its old flagless cookie. Logging out doesn't help either — `offensive/logout.php` calls `session_unset()`, which empties `$_SESSION` but leaves the session and its cookie in place.

Those cookies would have been replaced only as each browser happened to discard them. With `cookie_lifetime = 0` that means whenever the user next fully quits their browser — days, unevenly, and with no way to tell who's still exposed.

## The change

Rename `TMBOSESS1` → `TMBOSESS2` at all three `session_start()` call sites. PHP locates a session by the cookie named in `session.name`, so renaming orphans every live session, and the next request from each client is issued a fresh cookie carrying both flags.

Most users won't notice — a valid `remember` cookie signs them straight back in.

The comment in `header.inc` now logs the reason for each bump. That reason is the only thing that makes a name like `TMBOSESS2` legible six months from now, and `DEPLOYING` already points at this as the site-wide logout mechanism.

## Testing

Three files lint clean against PHP 5.6, and all call sites confirmed to use exactly one name.

After deploy, load the site and confirm `TMBOSESS2` appears with `Secure` and `HttpOnly`, and that `TMBOSESS1` is gone.

## Note

Orphaned `TMBOSESS1` session files stay on disk — `session.gc_probability` is 0 and no cron collects them. Clearing `/var/lib/php5/sessions` needs root on the host. Not new and not blocking, but the pile grows with each bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)